### PR TITLE
echo_sosp: Reset server timer on print

### DIFF
--- a/examples/echo_sosp.rs
+++ b/examples/echo_sosp.rs
@@ -125,6 +125,7 @@ impl<
         loop {
             // Dump statistics.
             if every_second_timer.elapsed() > Duration::from_secs(1) {
+                self.libos.get_and_reset_time();
                 dbg!(&processed_packages);
                 println!(
                     "{} gbps",


### PR DESCRIPTION
If the timer is not reset, it eventually overflows with:

```
thread 'main' panicked at 'attempt to add with overflow', <...>/io-queue-rdma/src/executor.rs:231:26
```